### PR TITLE
FFImmunity and Command and CedmodPlayer.Get Update

### DIFF
--- a/CedMod/Addons/AdminSitSystem/Commands/Jail/Add.cs
+++ b/CedMod/Addons/AdminSitSystem/Commands/Jail/Add.cs
@@ -46,8 +46,12 @@ namespace CedMod.Addons.AdminSitSystem.Commands.Jail
 
             var loc = AdminSitHandler.Singleton.Sits.FirstOrDefault(s => s.Players.Any(s => s.UserId == invoker.UserId)).Location;
             
-            var plr = CedModPlayer.Get(int.Parse(arguments.At(0)));
-            
+            var plr = CedModPlayer.Get(arguments.At(0));
+            if (plr is null)
+            {
+                response = $"Player '{arguments.At(0)}' could not be found";
+                return false;
+            }
             if (AdminSitHandler.Singleton.Sits.Any(s => s.Players.Any(s => s.UserId == plr.UserId)))
             {
                 response = "The specified player is already part of a jail.";

--- a/CedMod/Addons/AdminSitSystem/Commands/Jail/Join.cs
+++ b/CedMod/Addons/AdminSitSystem/Commands/Jail/Join.cs
@@ -39,6 +39,11 @@ namespace CedMod.Addons.AdminSitSystem.Commands.Jail
             
             var invoker = CedModPlayer.Get((sender as CommandSender).SenderId);
             var plr = CedModPlayer.Get(int.Parse(arguments.At(0)));
+            if (plr == null)
+            {
+                response = $"Player '{arguments.At(0)}' could not be found.";
+                return false;
+            }
             if (!AdminSitHandler.Singleton.Sits.Any(s => s.Players.Any(s => s.UserId == plr.UserId)))
             {
                 response = "The specified player is not part of any jail.";

--- a/CedMod/Addons/AdminSitSystem/Commands/Jail/Remove.cs
+++ b/CedMod/Addons/AdminSitSystem/Commands/Jail/Remove.cs
@@ -54,7 +54,12 @@ namespace CedMod.Addons.AdminSitSystem.Commands.Jail
                 return false;
             }
 
-            var plr = CedModPlayer.Get(int.Parse(arguments.At(0)));
+            var plr = CedModPlayer.Get(arguments.At(0));
+            if (plr == null)
+            {
+                response = $"Player '{arguments.At(0)}' could not be found.";
+                return false;
+            }
             var sit = AdminSitHandler.Singleton.Sits.FirstOrDefault(s => s.Players.Any(s => s.UserId == plr.UserId));
             if (sit == null)
             {

--- a/CedMod/CedModPlayer.cs
+++ b/CedMod/CedModPlayer.cs
@@ -12,12 +12,60 @@ namespace CedMod
 
         public static CedModPlayer Get(string userid)
         {
+            // Check id
+            if (int.TryParse(userid, out int id))
+                return Get<CedModPlayer>(id);
+
+            // Check Userid
+            if (userid.EndsWith("@steam") || userid.EndsWith("@discord") || userid.EndsWith("@northwood") ||
+                userid.EndsWith("@patreon"))
+            {
             foreach (var hub in ReferenceHub.AllHubs)
             {
                 if (hub.characterClassManager.UserId == userid)
                     return Get<CedModPlayer>(hub);
             }
 
+            }
+            else // Check username
+            {
+                var hub = processHubUsername(userid); // try getting a hub with no spaces
+                                                      
+                // if no hub is found, try again but replace any '_' with spaces
+                if (hub == null) // This Allows mods to select a user with a space in their name. 
+                    hub = processHubUsername(userid.Replace("_", " "));
+
+                if (hub == null) // if nobody is found after this, return null
+                    return null;
+
+                return Get<CedModPlayer>(hub);
+            }
+
+            return null;
+        }
+
+        private static ReferenceHub processHubUsername(string userid)
+        {
+            int lastnameDifference = 31;
+            string firstString = userid.ToLower();
+
+            foreach (ReferenceHub player in ReferenceHub.AllHubs)
+            {
+                if (player.nicknameSync.Network_myNickSync == null)
+                    continue;
+
+                if (!player.nicknameSync.Network_myNickSync.ToLower().Contains(userid.ToLower()))
+                    continue;
+
+                string secondString = player.nicknameSync.Network_myNickSync.ToLower();
+
+                int nameDifference = secondString.Length - firstString.Length;
+                if (nameDifference < lastnameDifference)
+                {
+                    lastnameDifference = nameDifference;
+                    return player;
+                }
+            }
             return null;
         }
         

--- a/CedMod/FriendlyFireAutoban.cs
+++ b/CedMod/FriendlyFireAutoban.cs
@@ -6,6 +6,7 @@ using InventorySystem.Disarming;
 using PlayerRoles;
 using PlayerStatsSystem;
 using PluginAPI.Core;
+using RemoteAdmin;
 
 namespace CedMod
 {
@@ -17,8 +18,17 @@ namespace CedMod
         {
             if (!RoundSummary.RoundInProgress() || !CedModMain.Singleton.Config.CedMod.AutobanEnabled || AdminDisabled || !IsTeamKill(player, attacker, damageHandler))
                 return;
+            bool attackerHasFFImmunity = false;
+            if (new PlayerCommandSender(attacker.ReferenceHub).CheckPermission(new PlayerPermissions[]
+                {
+                    PlayerPermissions.FriendlyFireDetectorImmunity
+                }))
+            {
+                attackerHasFFImmunity = true;
+            }
             
-            string ffaTextKiller = $"<size=25><b><color=yellow>You teamkilled: </color></b><color=red> {player.Nickname} </color><color=yellow><b> If you continue teamkilling it will result in a ban</b></color></size>";
+            string resultOfTK = attackerHasFFImmunity ? "<color=#49E1E9><b> You have Friendly Fire Ban Immunity.</b></color>" : "<color=yellow><b> If you continue teamkilling it will result in a ban</b></color>";
+            string ffaTextKiller = $"<size=25><b><color=yellow>You teamkilled: </color></b><color=red> {player.Nickname} </color><br>{resultOfTK}</size>";
             attacker.ReferenceHub.hints.Show(new TextHint(ffaTextKiller, new HintParameter[] {new StringHintParameter("")}, null, 20f));
             attacker.SendConsoleMessage(ffaTextKiller, "white");
             string ffaTextVictim = $"<size=25><b><color=yellow>You have been teamkilled by: </color></b></size><color=red><size=25> {attacker.Nickname} ({attacker.UserId} {attacker.Role} You were a {player.Role}</size></color>\n<size=25><b><color=yellow> Use this as a screenshot as evidence for a report</color></b>\n{CedModMain.Singleton.Config.CedMod.AutobanExtraMessage}\n</size><size=25><i><color=yellow> Note: if they continues to teamkill the server will ban them</color></i></size>";
@@ -34,11 +44,8 @@ namespace CedMod
             else
                 Teamkillers.Add(attacker.UserId, 1);
 
-            if (new PlayerCommandSender(attacker.ReferenceHub).CheckPermission(new PlayerPermissions[]
+            if (attackerHasFFImmunity)
                 {
-                    PlayerPermissions.FriendlyFireDetectorImmunity
-                }))
-            {
                 return;
             }
 

--- a/CedMod/FriendlyFireAutoban.cs
+++ b/CedMod/FriendlyFireAutoban.cs
@@ -34,6 +34,14 @@ namespace CedMod
             else
                 Teamkillers.Add(attacker.UserId, 1);
 
+            if (new PlayerCommandSender(attacker.ReferenceHub).CheckPermission(new PlayerPermissions[]
+                {
+                    PlayerPermissions.FriendlyFireDetectorImmunity
+                }))
+            {
+                return;
+            }
+
             foreach (KeyValuePair<string, int> s in Teamkillers)
             {
                 if (s.Key == attacker.UserId)


### PR DESCRIPTION
### FFImmunity:
 - Added a check in the friendly fire autoban system to see if a user has the FFImmunity Permission. (Players will still see the message if the user kills them)

### CedModPlayer Get(string userid):
 - Now checks for the userId, playerId, and nickname. (Nicknames can also have `_` substituted for a space). This is a non-breaking change, and any previous code will still work to find a userid first.

### Command Updates:
 - Updated the jail `add, remove, and join` commands.
 - They now use `CedModPlayer.Get(string userid)` instead of `CedModPlayer.Get(int playerid)`
 - They now check to see if the player is null, and return false with the message `Could not find player`