### PR TITLE
FF Autoban pink candy addition

### DIFF
--- a/CedMod/CedModConfig.cs
+++ b/CedMod/CedModConfig.cs
@@ -23,6 +23,9 @@ namespace CedMod
         [Description("The ban reason of the ban a user gets if the autoban is triggered")]
         public string AutobanReason { get; set; } = "You have been automatically banned for teamkilling";
         
+        [Description("If the autoban will count pink candy teamkills")]
+        public bool AutobanPinkCandies { get; set; } = true;
+        
         [Description("If the autoban will count killing disarmed class D as teamkill")]
         public bool AutobanDisarmedClassDTk { get; set; } = true;
         

--- a/CedMod/FriendlyFireAutoban.cs
+++ b/CedMod/FriendlyFireAutoban.cs
@@ -102,6 +102,12 @@ namespace CedMod
                 return false;
             if (attacker == player)
                 return false;
+
+            if (attacker.CurrentItem is not null && attacker.CurrentItem.name == "Scp330(Clone)" && !CedModMain.Singleton.Config.CedMod.AutobanPinkCandies)
+            {
+                return false;
+            }
+            
             switch (attacker.Role.GetTeam())
             {
                 case Team.ClassD when player.Role.GetTeam() == Team.ChaosInsurgency:


### PR DESCRIPTION
Adds a config option for if pink candy will count as a team kill.