### PR TITLE
Fix EXILED event plugin loading.

### DIFF
--- a/CedMod/Plugin.cs
+++ b/CedMod/Plugin.cs
@@ -322,14 +322,10 @@ namespace CedMod
                 foreach (var entryType in types)
                 {
 #if EXILED
-                    if ((object) entryType != null && entryType.IsGenericType)
+                    if (IsDerivedFromExiledPlugin(entryType))
                     {
-                        Type genericTypeDefinition = entryType.GetGenericTypeDefinition();
-                        if (genericTypeDefinition == typeof (Plugin<>) || genericTypeDefinition == typeof (Plugin<,>))
-                        {
-                            ExiledPlugin.Add(entryType.Assembly);
-                            continue;
-                        }
+                        ExiledPlugin.Add(entryType.Assembly);
+                        continue;
                     }
 #endif
                     if (!entryType.IsValidEntrypoint()) 
@@ -521,6 +517,23 @@ namespace CedMod
         {
             Disabled();
             base.OnDisabled();
+        }
+        
+        private bool IsDerivedFromExiledPlugin(Type type)
+        {
+            while (type != null)
+            {
+                type = type.BaseType;
+
+                if (type?.IsGenericType ?? false)
+                {
+                    Type genericDef = type.GetGenericTypeDefinition();
+                    if (genericDef == typeof(Plugin<>) || genericDef == typeof(Plugin<,>))
+                        return true;
+                }
+            }
+
+            return false;
         }
 #else
         [PluginUnload]

--- a/CedMod/Plugin.cs
+++ b/CedMod/Plugin.cs
@@ -385,8 +385,7 @@ namespace CedMod
                     }
                     else
                     {
-                        IEvent @event = constructor.Invoke(null) as IEvent;
-                        if (@event == null)
+                        if (plugin is not IEvent @event)
                             continue;
 
                         if (!@event.Config.IsEnabled)

--- a/CedMod/Plugin.cs
+++ b/CedMod/Plugin.cs
@@ -521,7 +521,7 @@ namespace CedMod
         
         private bool IsDerivedFromExiledPlugin(Type type)
         {
-            while (type != null)
+            while (type is not null)
             {
                 type = type.BaseType;
 


### PR DESCRIPTION
This allows EXILED plugins to properly be registered as events, by checking the *BaseType* rather than the entryType.

For example:
```cs
public namespace SomeEvent;

public class Plugin : Plugin<Config>, IEvent
{}
```
The `entryType` when cedmod is iterating `types` will be `SomeEvent.Plugin`.
Since this type itself is not generic, it skips it.

The fix resolves this issue, and also allows for these event plugins to inherit an external base class, but still be properly registered as EXILED plugins, via recursion.

For example:

```cs
namespace SomeDependency.API.Features;

public abstract class EventPlugin<TConfig> : Plugin<TConfig>, IEvent
    where TConfig : EventConfig, new()
{}

public class EventConfig : IConfig, IEventConfig
{
    public bool IsEnabled { get; set; }
    public bool Debug { get; set; }
}
```
```cs
namespace SomeEvent;

public class Plugin : EventPlugin<Config>
{}

public class Config : EventConfig
{}
```
would now still be valid.

It also removes the forced new IEvent instantiation, instead casting the EXILED plugin as IEvent, to allow that plugin to handle loading it's own Config prior to CedMod checking if it's enabled.

This could be changed later to make CedMod itself handle loading their configs, but would require an API breaking change to IEvent to add a setter to the Config property.