### PR TITLE
Move hardcoded Autoban messages into config

### DIFF
--- a/CedMod/CedModConfig.cs
+++ b/CedMod/CedModConfig.cs
@@ -21,20 +21,20 @@ namespace CedMod
         public int AutobanDuration { get; set; } = 4320;
 
         [Description("The Hint (message) the teamkilling victim will receive")]
-        public int AutobanVictimHint { get; set; } = "<size=25><b><color=yellow>You have been teamkilled by: </color></b></size><color=red><size=25> {attackerName} ({attackerID} {attackerRole} You were a {playerRole}</size></color>\n<size=25><b><color=yellow> Use this as a screenshot as evidence for a report</color></b>\n{AutobanExtraMessage}\n</size><size=25><i><color=yellow> Note: if they continues to teamkill the server will ban them</color></i></size>";
+        public string AutobanVictimHint { get; set; } = "<size=25><b><color=yellow>You have been teamkilled by: </color></b></size><color=red><size=25> {attackerName} ({attackerID} {attackerRole} You were a {playerRole}</size></color>\n<size=25><b><color=yellow> Use this as a screenshot as evidence for a report</color></b>\n{AutobanExtraMessage}\n</size><size=25><i><color=yellow> Note: if they continues to teamkill the server will ban them</color></i></size>";
         
         [Description("The Hint (message) the teamkilling perpetrator will receive")]
-        public int AutobanPerpetratorHint { get; set; } = "<color=yellow><b> If you continue teamkilling it will result in a ban</b></color>";
+        public string AutobanPerpetratorHint { get; set; } = "<color=yellow><b> If you continue teamkilling it will result in a ban</b></color>";
         
         [Description("The Hint (message) the teamkilling perpetrator will receive (displaying the user)")]
-        public int AutobanPerpetratorHintUser { get; set; } = "<b><color=yellow>You teamkilled: </color></b><color=red> {playerName} </color>";
+        public string AutobanPerpetratorHintUser { get; set; } = "<b><color=yellow>You teamkilled: </color></b><color=red> {playerName} </color>";
 
 
         [Description("The Hint (message) the teamkilling perpetrator will receive if he has FriendlyFire immunity ")]
-        public int AutobanPerpetratorHintImmunity { get; set; } = "<color=#49E1E9><b> You have Friendly Fire Ban Immunity.</b></color>";
+        public string AutobanPerpetratorHintImmunity { get; set; } = "<color=#49E1E9><b> You have Friendly Fire Ban Immunity.</b></color>";
 
         [Description("The Broadcast that will be displayed upon the player getting autobanned")]
-        public int AutobanBroadcastMesage { get; set; } = "<size=25><b><color=yellow>user: </color></b><color=red> {attackerName} </color><color=yellow><b> has been automatically banned for teamkilling</b></color></size>";
+        public string AutobanBroadcastMesage { get; set; } = "<size=25><b><color=yellow>user: </color></b><color=red> {attackerName} </color><color=yellow><b> has been automatically banned for teamkilling</b></color></size>";
         
         [Description("The ban reason of the ban a user gets if the autoban is triggered")]
         public string AutobanReason { get; set; } = "You have been automatically banned for teamkilling";

--- a/CedMod/CedModConfig.cs
+++ b/CedMod/CedModConfig.cs
@@ -26,7 +26,6 @@ namespace CedMod
         [Description("The Hint (message) the teamkilling perpetrator will receive")]
         public int AutobanPerpetratorHint { get; set; } = "<color=yellow><b> If you continue teamkilling it will result in a ban</b></color>";
         
-        
         [Description("The Hint (message) the teamkilling perpetrator will receive (displaying the user)")]
         public int AutobanPerpetratorHintUser { get; set; } = "<b><color=yellow>You teamkilled: </color></b><color=red> {playerName} </color>";
 
@@ -36,8 +35,6 @@ namespace CedMod
 
         [Description("The Broadcast that will be displayed upon the player getting autobanned")]
         public int AutobanBroadcastMesage { get; set; } = "<size=25><b><color=yellow>user: </color></b><color=red> {attackerName} </color><color=yellow><b> has been automatically banned for teamkilling</b></color></size>";
-
-
         
         [Description("The ban reason of the ban a user gets if the autoban is triggered")]
         public string AutobanReason { get; set; } = "You have been automatically banned for teamkilling";

--- a/CedMod/CedModConfig.cs
+++ b/CedMod/CedModConfig.cs
@@ -19,6 +19,25 @@ namespace CedMod
         
         [Description("The duration of the autoban ban a user will get if the autoban is triggered in MINUTES")]
         public int AutobanDuration { get; set; } = 4320;
+
+        [Description("The Hint (message) the teamkilling victim will receive")]
+        public int AutobanVictimHint { get; set; } = "<size=25><b><color=yellow>You have been teamkilled by: </color></b></size><color=red><size=25> {attackerName} ({attackerID} {attackerRole} You were a {playerRole}</size></color>\n<size=25><b><color=yellow> Use this as a screenshot as evidence for a report</color></b>\n{AutobanExtraMessage}\n</size><size=25><i><color=yellow> Note: if they continues to teamkill the server will ban them</color></i></size>";
+        
+        [Description("The Hint (message) the teamkilling perpetrator will receive")]
+        public int AutobanPerpetratorHint { get; set; } = "<color=yellow><b> If you continue teamkilling it will result in a ban</b></color>";
+        
+        
+        [Description("The Hint (message) the teamkilling perpetrator will receive (displaying the user)")]
+        public int AutobanPerpetratorHintUser { get; set; } = "<b><color=yellow>You teamkilled: </color></b><color=red> {playerName} </color>";
+
+
+        [Description("The Hint (message) the teamkilling perpetrator will receive if he has FriendlyFire immunity ")]
+        public int AutobanPerpetratorHintImmunity { get; set; } = "<color=#49E1E9><b> You have Friendly Fire Ban Immunity.</b></color>";
+
+        [Description("The Broadcast that will be displayed upon the player getting autobanned")]
+        public int AutobanBroadcastMesage { get; set; } = "<size=25><b><color=yellow>user: </color></b><color=red> {attackerName} </color><color=yellow><b> has been automatically banned for teamkilling</b></color></size>";
+
+
         
         [Description("The ban reason of the ban a user gets if the autoban is triggered")]
         public string AutobanReason { get; set; } = "You have been automatically banned for teamkilling";

--- a/CedMod/FriendlyFireAutoban.cs
+++ b/CedMod/FriendlyFireAutoban.cs
@@ -43,16 +43,17 @@ namespace CedMod
             attacker.SendConsoleMessage(ffaTextKiller, "white");
             Dictionary<string, string> autobanReplaceMap = new()
             {
-                {"attackerName", attacker.Nickname},
-                {"attackerID", attacker.UserId},
-                {"attackerRole", attacker.Role},
-                {"playerRole", player.Role},
-                {"AutobanExtraMessage", CedModMain.Singleton.Config.CedMod.AutobanExtraMessage},
-            }
+                { "attackerName", attacker.Nickname },
+                { "attackerID", attacker.UserId },
+                { "attackerRole", attacker.Role },
+                { "playerRole", player.Role },
+                { "AutobanExtraMessage", CedModMain.Singleton.Config.CedMod.AutobanExtraMessage },
+            };
 
             string ffaTextVictim = CedModMain.Singleton.Config.CedMod.AutobanVictimHint;
-            foreach (var key in autobanReplaceMap.Keys) {
-                ffaTextVictim = ffaTextVictim.Replace(key, autobanReplaceMap[key])
+            foreach (var key in autobanReplaceMap.Keys)
+            {
+                ffaTextVictim = ffaTextVictim.Replace(key, autobanReplaceMap[key]);
             }
 
             if (attacker.DoNotTrack)

--- a/CedMod/FriendlyFireAutoban.cs
+++ b/CedMod/FriendlyFireAutoban.cs
@@ -45,8 +45,8 @@ namespace CedMod
             {
                 { "{attackerName}", attacker.Nickname },
                 { "{attackerID}", attacker.UserId },
-                { "{attackerRole}", attacker.Role },
-                { "{playerRole}", player.Role },
+                { "{attackerRole}", attacker.Role.ToString() },
+                { "{playerRole}", player.Role.ToString() },
                 { "{AutobanExtraMessage}", CedModMain.Singleton.Config.CedMod.AutobanExtraMessage },
             };
 

--- a/CedMod/FriendlyFireAutoban.cs
+++ b/CedMod/FriendlyFireAutoban.cs
@@ -31,7 +31,7 @@ namespace CedMod
             });
 
             string resultOfTK = attackerHasFFImmunity ? CedModMain.Singleton.Config.CedMod.AutobanPerpetratorHintImmunity : CedModMain.Singleton.Config.CedMod.AutobanPerpetratorHint;
-            string ffaTextKiller = $"<size=25>{CedModMain.Singleton.Config.CedMod.AutobanPerpetratorHintUser.Replace("playerName", player.Nickname)}\n{resultOfTK}</size>";
+            string ffaTextKiller = $"<size=25>{CedModMain.Singleton.Config.CedMod.AutobanPerpetratorHintUser.Replace("{playerName}", player.Nickname)}\n{resultOfTK}</size>";
             if (behaviour != null)
             {
                 var msg = behaviour.KillerMessage(player, attacker, damageHandler);
@@ -43,11 +43,11 @@ namespace CedMod
             attacker.SendConsoleMessage(ffaTextKiller, "white");
             Dictionary<string, string> autobanReplaceMap = new()
             {
-                { "attackerName", attacker.Nickname },
-                { "attackerID", attacker.UserId },
-                { "attackerRole", attacker.Role },
-                { "playerRole", player.Role },
-                { "AutobanExtraMessage", CedModMain.Singleton.Config.CedMod.AutobanExtraMessage },
+                { "{attackerName}", attacker.Nickname },
+                { "{attackerID}", attacker.UserId },
+                { "{attackerRole}", attacker.Role },
+                { "{playerRole}", player.Role },
+                { "{AutobanExtraMessage}", CedModMain.Singleton.Config.CedMod.AutobanExtraMessage },
             };
 
             string ffaTextVictim = CedModMain.Singleton.Config.CedMod.AutobanVictimHint;
@@ -91,7 +91,7 @@ namespace CedMod
                             {
                                 await API.Ban(attacker, (long) banDuration.TotalSeconds, "Server.Module.FriendlyFireAutoban", banReason, false);
                             });
-                            Server.SendBroadcast(CedModMain.Singleton.Config.CedMod.AutobanBroadcastMesage.Replace("attackerName", attacker.Nickname), 20);
+                            Server.SendBroadcast(CedModMain.Singleton.Config.CedMod.AutobanBroadcastMesage.Replace("{attackerName}", attacker.Nickname), 20);
                         }
                     }
                 }

--- a/CedMod/FriendlyFireAutoban.cs
+++ b/CedMod/FriendlyFireAutoban.cs
@@ -30,8 +30,8 @@ namespace CedMod
                 PlayerPermissions.FriendlyFireDetectorImmunity
             });
 
-            string resultOfTK = attackerHasFFImmunity ? "<color=#49E1E9><b> You have Friendly Fire Ban Immunity.</b></color>" : "<color=yellow><b> If you continue teamkilling it will result in a ban</b></color>";
-            string ffaTextKiller = $"<size=25><b><color=yellow>You teamkilled: </color></b><color=red> {player.Nickname} </color>\n{resultOfTK}</size>";
+            string resultOfTK = attackerHasFFImmunity ? CedModMain.Singleton.Config.CedMod.AutobanPerpetratorHintImmunity : CedModMain.Singleton.Config.CedMod.AutobanPerpetratorHint;
+            string ffaTextKiller = $"<size=25>{CedModMain.Singleton.Config.CedMod.AutobanPerpetratorHintUser.Replace("playerName", player.Nickname)}\n{resultOfTK}</size>";
             if (behaviour != null)
             {
                 var msg = behaviour.KillerMessage(player, attacker, damageHandler);
@@ -41,7 +41,20 @@ namespace CedMod
                 
             attacker.ReferenceHub.hints.Show(new TextHint(ffaTextKiller, new HintParameter[] {new StringHintParameter("")}, null, 20f));
             attacker.SendConsoleMessage(ffaTextKiller, "white");
-            string ffaTextVictim = $"<size=25><b><color=yellow>You have been teamkilled by: </color></b></size><color=red><size=25> {attacker.Nickname} ({attacker.UserId} {attacker.Role} You were a {player.Role}</size></color>\n<size=25><b><color=yellow> Use this as a screenshot as evidence for a report</color></b>\n{CedModMain.Singleton.Config.CedMod.AutobanExtraMessage}\n</size><size=25><i><color=yellow> Note: if they continues to teamkill the server will ban them</color></i></size>";
+            Dictionary<string, string> autobanReplaceMap = new()
+            {
+                {"attackerName", attacker.Nickname},
+                {"attackerID", attacker.UserId},
+                {"attackerRole", attacker.Role},
+                {"playerRole", player.Role},
+                {"AutobanExtraMessage", CedModMain.Singleton.Config.CedMod.AutobanExtraMessage},
+            }
+
+            string ffaTextVictim = CedModMain.Singleton.Config.CedMod.AutobanVictimHint;
+            foreach (var key in autobanReplaceMap.Keys) {
+                ffaTextVictim = ffaTextVictim.Replace(key, autobanReplaceMap[key])
+            }
+
             if (attacker.DoNotTrack)
                 ffaTextVictim = ffaTextVictim.Replace(attacker.UserId, "DNT");
             
@@ -77,7 +90,7 @@ namespace CedMod
                             {
                                 await API.Ban(attacker, (long) banDuration.TotalSeconds, "Server.Module.FriendlyFireAutoban", banReason, false);
                             });
-                            Server.SendBroadcast($"<size=25><b><color=yellow>user: </color></b><color=red> {attacker.Nickname} </color><color=yellow><b> has been automatically banned for teamkilling</b></color></size>", 20);
+                            Server.SendBroadcast(CedModMain.Singleton.Config.CedMod.AutobanBroadcastMesage.Replace("attackerName", attacker.Nickname), 20);
                         }
                     }
                 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-CedMod builds are located on the Releases tab Please note that there are always 2 releases for each version, one for the NWApi and one for EXILED. Please take note of this when installing.
+CedMod builds are located on the Releases tab. Please note that there are always 2 releases for each version, one for the NWApi and one for EXILED. Please take note of this when installing.
 The CedMod instance creation guide https://cedmod.nl/Servers/Create will also provide the 2 releases after creating an instance.
-if you already have an instance the "View Setup command" or "Add new QueryServer" button will also provide you with the releases in question.
+If you already have an instance, the "View Setup command" or "Add new QueryServer" button will also provide you with the releases in question.
 
 About CedMod: https://cedmod.nl/About
 
@@ -15,15 +15,20 @@ Support discord: https://discord.gg/p69SGfwxxm
 | is_enabled                          |   bool    | true     | If the plugin is enabled                                                   |
 | kick_same_name                      |   bool    | true     | If Users with the same name will be kick                                   |
 | ced_mod_api_api                     |   string  | none     | API Key for the CedMod API                                                 |
-| autoban_enabled                     |   bool    | false    | if the FF autoban is enabled                                               |
-| autoban_threshold                   |   int     | 3        | the amount of Teamkills before the autoban will ban                        |
-| autoban_duration                    |   int     | 4320     | the amount of time a user will be banned after triggering the autoban      |
-| autoban_reason                      |   string  | You have teamkilled too many people | the reason for the autoban bans                 |
-| autoban_disarmed_class_d_tk         |   bool    | true     | if disarmed class D kills are considered teamkills                         | 
-| autoban_disarmed_scientist_d_tk     |   bool    | true     | if disarmed scientist kills are considered teamkills                       |
-| autoban_class_dvs_class_d           |   bool    | true     | if class D vs class D kills are considered teamkills                       |
-| report_blacklist                    |   list    | []       | userids in this list will not be able to use ingame reports                |
-| staff_report_allowed                |   bool    | false    | if staff can be reported using ingame reports                              |
+| autoban_enabled                     |   bool    | false    | If the FF autoban is enabled                                               |
+| autoban_threshold                   |   int     | 3        | The amount of Teamkills before the autoban will ban                        |
+| autoban_duration                    |   int     | 4320     | The amount of time a user will be banned after triggering the autoban      |
+| autoban_reason                      |   string  | You have teamkilled too many people | The reason for the autoban bans                 |
+| autoban_disarmed_class_d_tk         |   bool    | true     | If disarmed class D kills are considered teamkills                         |
+| autoban_disarmed_scientist_d_tk     |   bool    | true     | If disarmed scientist kills are considered teamkills                       |
+| autoban_class_dvs_class_d           |   bool    | true     | If class D vs class D kills are considered teamkills                       |
+| autoban_victim_hint                 |   string  | <size=25><b><color=yellow>You have been teamkilled by: </color></b></size><color=red><size=25> {attackerName} ({attackerID} {attackerRole} You were a {playerRole}</size></color>\n<size=25><b><color=yellow> Use this as a screenshot as evidence for a report</color></b>\n{AutobanExtraMessage}\n</size><size=25><i><color=yellow> Note: if they continues to teamkill the server will ban them</color></i></size> | Hint message the teamkilling victim will receive |
+| autoban_perpetrator_hint            |   string  | <color=yellow><b> If you continue teamkilling it will result in a ban</b></color> | Hint message the teamkilling perpetrator will receive |
+| autoban_perpetrator_hint_user       |   string  | <b><color=yellow>You teamkilled: </color></b><color=red> {playerName} </color> | Hint message the teamkilling perpetrator will receive (displaying the user) |
+| autoban_perpetrator_hint_immunity   |   string  | <color=#49E1E9><b> You have Friendly Fire Ban Immunity.</b></color> | Hint message the teamkilling perpetrator will receive if they have FriendlyFire immunity |
+| autoban_broadcast_message           |   string  | <size=25><b><color=yellow>user: </color></b><color=red> {attackerName} </color><color=yellow><b> has been automatically banned for teamkilling</b></color></size> | Broadcast message displayed when a player gets autobanned |
+| report_blacklist                    |   list    | []       | User IDs in this list will not be able to use in-game reports              |
+| staff_report_allowed                |   bool    | false    | If staff can be reported using in-game reports                             |
 | staff_report_message                |   string  | You can not report a staff member | Message shown when staff reporting is not allowed |
 | additional_ban_message              |   string  | ""       | String appended to the ban kick message                                    |
 | show_debug                          |   bool    | false    | If debug messages are shown, Warning: This WILL spam your console          |
@@ -35,9 +40,9 @@ Support discord: https://discord.gg/p69SGfwxxm
 | cm_WAPI                                                                                                                                 |
 | is_enabled                          |   bool    | true     | If the plugin is enabled                                                   |
 | disallowed_web_commands             |   list    | []       | Commands that will not be able to run                                      |
-| security_key                        |   string  | string   | key for remote commands, set the same as in the panel                      |
+| security_key                        |   string  | string   | Key for remote commands, set the same as in the panel                      |
 | identifier                          |   string  | "Server 1"| The name that your server will appear as on the panel                     |
-| enable_ban_reason_sync              |   bool    | true     | If the querysystem should sync ban predefined ban reasons with the panel   |
+| enable_ban_reason_sync              |   bool    | true     | If the query system should sync predefined ban reasons with the panel      |
 | enable_external_lookup              |   bool    | true     | If External Lookup should be enabled automatically                         |
 | custom_sever_full_message           |   string  | ""       | The message shown to users once the server is full, leave empty for game default |
 | debug                               |   bool    | false    | If debug messages are shown, Warning: This WILL spam your console           |


### PR DESCRIPTION
This pull request introduces configurable hint messages and broadcast messages for the Friendly Fire autoban system, allowing for greater customization and maintainability. The changes include the addition of new configuration properties and updates to the `HandleKill` method to utilize these properties dynamically.

### Configuration Enhancements:

* Added several new properties to the `CedModConfig` class for customizable messages, including `AutobanVictimHint`, `AutobanPerpetratorHint`, `AutobanPerpetratorHintUser`, `AutobanPerpetratorHintImmunity`, and `AutobanBroadcastMesage`. These properties allow server administrators to define tailored messages for victims, perpetrators, and broadcasts related to teamkilling incidents.

### Code Refactoring for Dynamic Messaging:

* Updated the `HandleKill` method in `CedMod/FriendlyFireAutoban.cs` to dynamically retrieve and use the new configuration properties for perpetrator and victim messages. This includes replacing hardcoded strings with configuration-driven values for better flexibility. [[1]](diffhunk://#diff-1c4fb7c5705c4d6de52af7f540233d541d49c82da51c8692f53faf24d1c33b89L33-R34) [[2]](diffhunk://#diff-1c4fb7c5705c4d6de52af7f540233d541d49c82da51c8692f53faf24d1c33b89L44-R57)
* Introduced a `Dictionary` to map placeholders (e.g., `{attackerName}`, `{playerRole}`) to their respective values, enabling dynamic placeholder replacement in victim messages.
* Replaced the hardcoded broadcast message with the `AutobanBroadcastMesage` configuration property, allowing for customizable autoban announcements.

_thx copilot for the description_