### PR TITLE
[Teamkill log fix]

### DIFF
--- a/CedMod/Addons/QuerySystem/QueryPlayerEvents.cs
+++ b/CedMod/Addons/QuerySystem/QueryPlayerEvents.cs
@@ -494,7 +494,7 @@ namespace CedMod.Addons.QuerySystem
             });
         }
 
-        public override void OnPlayerDeath(PlayerDeathEventArgs ev)
+        public override void OnPlayerDying(PlayerDyingEventArgs ev)
         {
             if (ev.Player == null || ev.Attacker == null)
                 return;


### PR DESCRIPTION
- Replaced OnPlayerDeath event with OnPlayerDying.

This fixes the teamkill logs.