### PR TITLE
Fixed whitelist

### DIFF
--- a/CedMod/Addons/QuerySystem/ThreadDispatcher.cs
+++ b/CedMod/Addons/QuerySystem/ThreadDispatcher.cs
@@ -35,8 +35,11 @@ namespace CedMod.Addons.QuerySystem
         public static ConcurrentQueue<Action> ThreadDispatchQueue = new ConcurrentQueue<Action>();
         public void Update()
         {
-            if (QuerySystem.UseWhitelist && !ServerConsole.WhiteListEnabled)
+            if (QuerySystem.UseWhitelist)
+            {
                 ServerConsole.WhiteListEnabled = true;
+                WhiteList.WhitelistEnabled = true;
+            }
             
             if (ThreadDispatchQueue.TryDequeue(out Action action))
             {

--- a/CedMod/Addons/QuerySystem/WS/WebSocketSystem.cs
+++ b/CedMod/Addons/QuerySystem/WS/WebSocketSystem.cs
@@ -971,6 +971,7 @@ namespace CedMod.Addons.QuerySystem.WS
                                 QuerySystem.Whitelist = whitelist;
                                 QuerySystem.UseWhitelist = true;
                                 ServerConsole.WhiteListEnabled = true;
+                                WhiteList.WhitelistEnabled = true;
                                 if (Directory.Exists(Path.Combine(CedModMain.PluginConfigFolder, "CedMod")))
                                 {
                                     File.WriteAllText(Path.Combine(CedModMain.PluginConfigFolder, "CedMod", "whitelistCache.json"), data);
@@ -984,6 +985,7 @@ namespace CedMod.Addons.QuerySystem.WS
                                 QuerySystem.Whitelist = new List<string>();
                                 QuerySystem.UseWhitelist = false;
                                 ServerConsole.WhiteListEnabled = false;
+                                WhiteList.WhitelistEnabled = false;
                                 if (Directory.Exists(Path.Combine(CedModMain.PluginConfigFolder, "CedMod")))
                                 {
                                     if (File.Exists(Path.Combine(CedModMain.PluginConfigFolder, "CedMod", "whitelistCache.json")))
@@ -1003,6 +1005,7 @@ namespace CedMod.Addons.QuerySystem.WS
                                         QuerySystem.Whitelist = whitelist;
                                         QuerySystem.UseWhitelist = true;
                                         ServerConsole.WhiteListEnabled = true;
+                                        WhiteList.WhitelistEnabled = true;
                                         Logger.Info("Loaded whitelist from file");
                                         CheckWhitelist();
                                     }


### PR DESCRIPTION
The `ServerConsole.WhiteListEnabled` value is used to check whether to show the server as whitelisted on the server list.
The `WhiteList.WhitelistEnabled` is used to actually enable a whitelist and used to enforce it by the base game.

So, both need to be set for the whitelist to work properly. The `ServerConsole.WhiteListEnabled` was already working, this just updates the `WhiteList.WhitelistEnabled` in the same places as the `ServerConsole` already was.