### PR TITLE
Setup error changes

### DIFF
--- a/CedMod/CedMod-Main.csproj
+++ b/CedMod/CedMod-Main.csproj
@@ -158,6 +158,9 @@
     <Compile Include="Commands\WarnCommand.cs" />
     <Compile Include="Components\AutoUpdater.cs" />
     <Compile Include="Components\RemoteAdminModificationHandler.cs" />
+    <Compile Include="Error\ContinuousError.cs" />
+    <Compile Include="Error\ErrorCollector.cs" />
+    <Compile Include="Error\PluginLibrary.cs" />
     <Compile Include="FriendlyFireAutoban.cs" />
     <Compile Include="Handlers\Player.cs" />
     <Compile Include="Config.cs" />

--- a/CedMod/Components/AutoUpdater.cs
+++ b/CedMod/Components/AutoUpdater.cs
@@ -20,25 +20,20 @@ namespace CedMod.Components
     public class AutoUpdater: MonoBehaviour
     {
         public static CedModVersion Pending = new CedModVersion();
+        
         public float TimePassed;
         public float TimePassedCheck;
-        
-        public float TimePassedWarning;
         public float TimePassedUpdateNotify;
+        
         public bool Installing = false;
         public Byte[] FileToWriteDelayed;
+        
         public bool ForceLog { get; set; }
 
         public void Update()
         {
             if (QuerySystem.QuerySystemKey == "")
             {
-                TimePassedWarning += Time.unscaledDeltaTime;
-                if (TimePassedWarning >= 2)
-                {
-                    TimePassedWarning = 0;
-                    Logger.Error($"CedMod requires additional Setup, the plugin will not function and some features will not work if the plugin is not setup.\nPlease follow the setup guide on https://cedmod.nl/Servers/Create");
-                }
                 return;
             }
             

--- a/CedMod/Error/ContinuousError.cs
+++ b/CedMod/Error/ContinuousError.cs
@@ -1,0 +1,20 @@
+using UnityEngine;
+
+namespace CedMod.Error
+{
+    public class ContinuousError : MonoBehaviour
+    {
+        private const int TimeBetween = 60;
+
+        private float _remaining = TimeBetween;
+
+        private void Update()
+        {
+            _remaining -= Time.unscaledDeltaTime;
+
+            if (_remaining > 0) return;
+            _remaining = TimeBetween;
+            ErrorCollector.SendErrors();
+        }
+    }
+}

--- a/CedMod/Error/ErrorCollector.cs
+++ b/CedMod/Error/ErrorCollector.cs
@@ -1,0 +1,114 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using CedMod.Addons.QuerySystem;
+using LabApi.Events.Handlers;
+using LabApi.Loader;
+using UnityEngine;
+using Logger = LabApi.Features.Console.Logger;
+
+namespace CedMod.Error
+{
+    internal static class ErrorCollector
+    {
+        private static GameObject _obj;
+        private static readonly List<string> Errors = new();
+
+        private static PluginLibrary? _currentLibrary;
+
+#if EXILED
+        private const PluginLibrary TargetLibrary = PluginLibrary.Exiled;
+#else
+        private const PluginLibrary TargetLibrary = PluginLibrary.LabAPI;
+#endif
+
+        internal static void Setup()
+        {
+            _obj = new GameObject();
+            Object.DontDestroyOnLoad(_obj);
+
+            _obj.AddComponent<ContinuousError>();
+
+            ServerEvents.WaitingForPlayers += WaitingForPlayers;
+        }
+
+        internal static void Destroy()
+        {
+            Object.Destroy(_obj);
+
+            ServerEvents.WaitingForPlayers -= WaitingForPlayers;
+        }
+
+        internal static void Add(string content)
+        {
+            Errors.Add(content);
+            SendErrors();
+        }
+
+        internal static void SendErrors(bool initial = false)
+        {
+            CheckLibrary();
+
+            var allErrors = CollectAllErrors();
+            if (allErrors.Count == 0)
+            {
+                if (initial)
+                {
+                    Logger.Info("No CedMod setup errors found during startup");
+                }
+
+                return;
+            }
+
+            var builder = new StringBuilder(" --------- [ CedMod setup error(s) ] --------- \n" +
+                                            "One or more errors have been found in your CedMod setup. CedMod may not function properly until all errors are resolved!.\n\n");
+
+            foreach (var error in allErrors)
+            {
+                builder.Append(" - ").AppendLine(error);
+            }
+
+            builder.AppendLine();
+            builder.AppendLine(" ----------------------------------------------- ");
+
+            Logger.Error(builder.ToString());
+        }
+
+        private static List<string> CollectAllErrors()
+        {
+            var allErrors = new List<string>(Errors);
+
+            if (_currentLibrary != TargetLibrary)
+            {
+                allErrors.Add(
+                    $"Wrong CedMod version was installed! You installed CedMod for {TargetLibrary} but should have installed CedMod for {_currentLibrary}. Make sure you followed the installation instructions in the README (https://github.com/CedModV2/CedMod), or on the panel, for the plugin library you are using.");
+            }
+
+            if (string.IsNullOrWhiteSpace(QuerySystem.QuerySystemKey))
+            {
+                allErrors.Add(
+                    "CedMod requires additional Setup, the plugin will not function and some features will not work if the plugin is not setup.\nPlease follow the setup guide on https://cedmod.nl/Servers/Create");
+            }
+
+            return allErrors;
+        }
+
+        private static void CheckLibrary()
+        {
+            if (PluginLoader.EnabledPlugins.Select(plugin => plugin.Name)
+                .Any(loweredName => loweredName == "Exiled Loader"))
+            {
+                _currentLibrary = PluginLibrary.Exiled;
+                return;
+            }
+
+            _currentLibrary = PluginLibrary.LabAPI;
+        }
+
+        private static void WaitingForPlayers()
+        {
+            SendErrors(true);
+            ServerEvents.WaitingForPlayers -= WaitingForPlayers;
+        }
+    }
+}

--- a/CedMod/Error/PluginLibrary.cs
+++ b/CedMod/Error/PluginLibrary.cs
@@ -1,0 +1,8 @@
+﻿namespace CedMod.Error
+{
+    public enum PluginLibrary
+    {
+        LabAPI,
+        Exiled
+    }
+}

--- a/CedMod/Plugin.cs
+++ b/CedMod/Plugin.cs
@@ -19,6 +19,7 @@ using CedMod.Addons.Sentinal;
 using CedMod.Addons.Sentinal.Patches;
 using CedMod.Addons.StaffInfo;
 using CedMod.Components;
+using CedMod.Error;
 using CentralAuth;
 using CommandSystem;
 using Exiled.API.Enums;
@@ -111,10 +112,12 @@ namespace CedMod
         
         void LoadPlugin()
         {
+            ErrorCollector.Setup();
+            
 #if !EXILED
             if (Config == null)
             {
-                Timing.CallPeriodically(100000, 1, () => Logger.Error("Failed to load CedMod, your CedMod config file is invalid. Please make sure the config.yml file is valid, the config.yml file is located in the CedMod folder inside the folder you installed the dll into, if the file does not contain valid yml, delete it, or resolve issues, and restart."));
+                ErrorCollector.Add("Failed to load CedMod, your CedMod config file is invalid. Please make sure the config.yml file is valid, the config.yml file is located in the CedMod folder inside the folder you installed the dll into, if the file does not contain valid yml, delete it, or resolve issues, and restart.");
                 return;
             }
             
@@ -122,7 +125,7 @@ namespace CedMod
             bool loaded = (bool)loadProperty.GetValue(null);
             if (loaded)
             {
-                Timing.CallPeriodically(100000, 1, () => Logger.Error("It would appear that the LabApi tried loading CedMod twice, please ensure that you do not have CedMod installed twice"));
+                ErrorCollector.Add("It would appear that the LabApi tried loading CedMod twice, please ensure that you do not have CedMod installed twice");
                 return;
             }
             loadProperty.SetValue(null, true);
@@ -134,7 +137,7 @@ namespace CedMod
             bool loaded = (bool)loadProperty.GetValue(null);
             if (loaded)
             {
-                Timing.CallPeriodically(100000, 1, () => Logger.Error("It would appear that EXILED tried loading CedMod twice, please ensure that you do not have CedMod or EXILED installed twice"));
+                ErrorCollector.Add("It would appear that EXILED tried loading CedMod twice, please ensure that you do not have CedMod or EXILED installed twice");
                 return;
             }
             loadProperty.SetValue(null, true);
@@ -555,6 +558,8 @@ namespace CedMod
 #endif
         public void Disabled()
         {
+            ErrorCollector.Destroy();
+            
             var loadProperty = AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(s => s.GetName().Name == "CedModV3").GetType("CedMod.API").GetProperty("HasLoaded");
             loadProperty.SetValue(null, false);
             PlayerAuthenticationManager.OnInstanceModeChanged -= HandleInstanceModeChange;


### PR DESCRIPTION
Makes most of the setup errors appear every 60 seconds in the console, including the plugin requiring more setup, which previously appeared every 2 seconds. Should reduce spam.

The new error takes up more space, hopefully attracting more attention to setup mistakes.

Added an additional check to determine which plugin framework is being used (LabAPI/EXILED) and which framework the plugin was compiled for.

A check is always run on the first time waiting for players. If no errors were found on the first waiting for players, a success message is logged. (both should be easily found in the console when searching for "CedMod setup")